### PR TITLE
Update e2m-hass-brige to v1.0.0

### DIFF
--- a/e2m-hass-bridge/CHANGELOG.md
+++ b/e2m-hass-bridge/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.0.0-1
+- Updated e2m-hass-bridge to version [`v1.0.0`](https://github.com/nana4rider/e2m-hass-bridge/releases/tag/v1.0.0)
+
 ## v1.14.0-alpha
 
 - Updated e2m-hass-bridge to version [`v1.14.0`](https://github.com/nana4rider/e2m-hass-bridge/releases/tag/v1.14.0)

--- a/e2m-hass-bridge/config.yaml
+++ b/e2m-hass-bridge/config.yaml
@@ -3,7 +3,7 @@ description: This is an application for automatically discovering devices found 
 image: nana4rider/hassio-e2m-hass-bridge
 url: https://github.com/nana4rider/e2m-hass-bridge
 slug: e2m_hass_bridge
-version: v1.14.0-alpha10
+version: v1.0.0-1
 init: false
 services:
   - mqtt:need


### PR DESCRIPTION
This pull request updates the e2m-hass-bridge add-on to version [v1.0.0](https://github.com/nana4rider/e2m-hass-bridge/releases/tag/v1.0.0)