### PR TITLE
Update pc2mqtt to v1.9.2

### DIFF
--- a/pc2mqtt/CHANGELOG.md
+++ b/pc2mqtt/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.9.2-1
+- Updated pc2mqtt to version [`v1.9.2`](https://github.com/nana4rider/pc2mqtt/releases/tag/v1.9.2)
+
 ## v1.9.1-1
 - Updated pc2mqtt to version [`v1.9.1`](https://github.com/nana4rider/pc2mqtt/releases/tag/v1.9.1)
 

--- a/pc2mqtt/Dockerfile
+++ b/pc2mqtt/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base:stable
 ARG APP_VERSION=latest
 
-FROM nana4rider/pc2mqtt:${APP_VERSION} AS bridge
+FROM ghcr.io/nana4rider/pc2mqtt:${APP_VERSION} AS bridge
 
 ARG BUILD_FROM
 FROM ${BUILD_FROM}

--- a/pc2mqtt/config.yaml
+++ b/pc2mqtt/config.yaml
@@ -3,7 +3,7 @@ description: An application to automatically detect a PC as a switch device in H
 image: ghcr.io/nana4rider/hassio-pc2mqtt
 url: https://github.com/nana4rider/pc2mqtt
 slug: pc2mqtt
-version: v1.9.1-6
+version: v1.9.2-1
 init: false
 host_network: true
 services:


### PR DESCRIPTION
This pull request updates the pc2mqtt add-on to version [v1.9.2](https://github.com/nana4rider/pc2mqtt/releases/tag/v1.9.2)