### PR TITLE
Update pc2mqtt to v1.10.1

### DIFF
--- a/pc2mqtt/CHANGELOG.md
+++ b/pc2mqtt/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.10.1-1
+- Updated pc2mqtt to version [`v1.10.1`](https://github.com/nana4rider/pc2mqtt/releases/tag/v1.10.1)
+
 ## v1.10.0-1
 - Updated pc2mqtt to version [`v1.10.0`](https://github.com/nana4rider/pc2mqtt/releases/tag/v1.10.0)
 

--- a/pc2mqtt/config.yaml
+++ b/pc2mqtt/config.yaml
@@ -3,7 +3,7 @@ description: An application to automatically detect a PC as a switch device in H
 image: ghcr.io/nana4rider/hassio-pc2mqtt
 url: https://github.com/nana4rider/pc2mqtt
 slug: pc2mqtt
-version: v1.10.0-1
+version: v1.10.1-1
 init: false
 host_network: true
 services:


### PR DESCRIPTION
This pull request updates the pc2mqtt add-on to version [v1.10.1](https://github.com/nana4rider/pc2mqtt/releases/tag/v1.10.1)